### PR TITLE
 Adds support for bot replies in quickstart-frame integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.1",
   "private": true,
   "dependencies": {
+    "@xmtp/content-type-reply": "^1.1.11",
     "@xmtp/frames-client": "^0.5.3",
     "@xmtp/xmtp-js": "^11.6.2",
     "axios": "^1.5.0",

--- a/src/FloatingInbox-text/ListConversations.js
+++ b/src/FloatingInbox-text/ListConversations.js
@@ -24,11 +24,13 @@ export const ListConversations = ({
   const [activeTab, setActiveTab] = useState("allowed"); // Added state for active tab
 
   const hightlightConversation = (conversation) => {
-    selectConversation(conversation);
-    setSelectedConversation(conversation.peerAddress);
-    if (conversation.peerAddress) {
+    if (conversation && conversation.peerAddress) {
+      selectConversation(conversation);
+      setSelectedConversation(conversation.peerAddress);
+
       console.log("Navigating to conversation:", conversation.consentState);
       navigate(`/dm/${conversation.peerAddress}`, {});
+
       if (isConsent && conversation.consentState !== "allowed") {
         setActiveTab("requests");
       }

--- a/src/FloatingInbox-text/MessageItem.js
+++ b/src/FloatingInbox-text/MessageItem.js
@@ -204,14 +204,22 @@ export const MessageItem = ({ message, senderAddress, client }) => {
     const codec = client.codecFor(message.contentType);
     let content = message.content;
 
-    if (frameMetadata?.url && showFrame)
-      content = content.replace(frameMetadata?.url, "");
+    // Handle 'reply' content type by accessing message.content.content
+    if (message.contentType === "reply") {
+      content = message.content.content;
+    }
+    if (frameMetadata?.url && showFrame) {
+      content = content.replace(frameMetadata.url, "");
+    }
+
     if (!codec) {
       /*Not supported content type*/
       if (message?.contentFallback !== undefined)
         content = message?.contentFallback;
       else return;
     }
+
+    // Render the content safely
     return (
       <div style={styles.messageContent}>
         {showFrame && frameMetadata?.frameInfo && (
@@ -220,7 +228,7 @@ export const MessageItem = ({ message, senderAddress, client }) => {
               <div style={styles.renderedMessage}>{"Loading..."}</div>
             )}
             <Frame
-              image={frameMetadata?.frameInfo?.image.content}
+              image={frameMetadata?.frameInfo?.image?.content}
               title={getFrameTitle(frameMetadata)}
               buttons={getOrderedButtons(frameMetadata)}
               handleClick={handleFrameButtonClick}
@@ -235,11 +243,15 @@ export const MessageItem = ({ message, senderAddress, client }) => {
             />
           </>
         )}
-        <div style={styles.renderedMessage}>{content}</div>
+        {/* Ensure content is rendered safely */}
+        <div style={styles.renderedMessage}>
+          {typeof content === "string" ? content : content.content}
+        </div>
         {renderFooter(message.sent)}
       </div>
     );
   };
+
   const [showAlert, setShowAlert] = useState(false);
   const [alertMessage, setAlertMessage] = useState("");
   const isSender = senderAddress === client?.address;

--- a/src/FloatingInbox-text/index.js
+++ b/src/FloatingInbox-text/index.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from "react";
 import { Client } from "@xmtp/xmtp-js";
+import { ReplyCodec } from "@xmtp/content-type-reply";
 import { ethers } from "ethers";
 import { ConversationContainer } from "./ConversationContainer";
 import { MessageContainer } from "./MessageContainer";
@@ -321,6 +322,7 @@ export function FloatingInbox({
         ...clientOptions,
         privateKeyOverride: keys,
       });
+      xmtp.registerCodec(new ReplyCodec());
       setClient(xmtp);
       setIsOnNetwork(!!xmtp.address);
     } catch (e) {


### PR DESCRIPTION
### What does this PR do?  
- This PR adds functionality to enable **bot replies** within the **quickstart-frame** integration.
- It addresses the issue where **quickstart-frame** was not able to handle bot replies created using `message-kit`, limiting the ability to interact with bots in frame-based applications.

### Related issue  
-  #8 

### Implementation details  
- The solution adds support for bot replies by **registering the appropriate codec** required for handling bot replies within frames.
- The following codec has been added to resolve the issue:

```javascript
xmtp.registerCodec(new ReplyCodec());
```

- This allows frames to listen for bot replies, enhancing bot interactions within the XMTP framework.

### Use cases unlocked
- Developers can now build chatbots that respond within frames, enabling advanced communication flows.
- Applications like **web3 payment systems**, **customer support bots**, and more can now seamlessly integrate bots with frame interactions.
- This provides a smooth developer experience for those working on top of XMTP, and no longer requires relying on alternative solutions like **Converse**, which lacks transaction support for open-frames.

### Additional information
- After carefully reviewing the XMTP documentation, the integration of the **Reply Codec** resolves the issue.
- The **bot replies** feature will enhance the overall functionality and user experience within frame-based applications on XMTP.
